### PR TITLE
perf:#22 optimize post list retrieval with index and slice pagination

### DIFF
--- a/backend/src/main/java/com/mateandgit/devstep/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/mateandgit/devstep/domain/post/controller/PostController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -32,10 +33,10 @@ public class PostController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<ApiResponse<Page<PostResponse>>> getPostList(
+    public ResponseEntity<ApiResponse<Slice<PostResponse>>> getPostList(
             Pageable pageable,
             @ModelAttribute PostSearchCondition condition) {;
-        Page<PostResponse> postList = postService.getPostList(pageable, condition);
+        Slice<PostResponse> postList = postService.getPostList(pageable, condition);
         return ResponseEntity.ok(ApiResponse.success(postList));
     }
 

--- a/backend/src/main/java/com/mateandgit/devstep/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/mateandgit/devstep/domain/post/entity/Post.java
@@ -21,6 +21,9 @@ import java.util.List;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "post", indexes = {
+        @Index(name = "idx_post_created_at", columnList = "created_at DESC")
+})
 public class Post {
 
     @Id

--- a/backend/src/main/java/com/mateandgit/devstep/domain/post/repository/PostRepositoryCustom.java
+++ b/backend/src/main/java/com/mateandgit/devstep/domain/post/repository/PostRepositoryCustom.java
@@ -4,7 +4,8 @@ import com.mateandgit.devstep.domain.post.dto.request.PostSearchCondition;
 import com.mateandgit.devstep.domain.post.dto.response.PostResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface PostRepositoryCustom {
-    Page<PostResponse> searchGetPost(Pageable pageable, PostSearchCondition condition);
+    Slice<PostResponse> searchGetPost(Pageable pageable, PostSearchCondition condition);
 }

--- a/backend/src/main/java/com/mateandgit/devstep/domain/post/repository/PostRepositoryImpl.java
+++ b/backend/src/main/java/com/mateandgit/devstep/domain/post/repository/PostRepositoryImpl.java
@@ -4,12 +4,11 @@ import com.mateandgit.devstep.domain.post.dto.request.PostSearchCondition;
 import com.mateandgit.devstep.domain.post.dto.response.PostResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
@@ -17,14 +16,14 @@ import java.util.List;
 import static com.mateandgit.devstep.domain.post.entity.QPost.post;
 
 @RequiredArgsConstructor
-public class PostRepositoryImpl implements PostRepositoryCustom{
+public class PostRepositoryImpl implements PostRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<PostResponse> searchGetPost(Pageable pageable, PostSearchCondition condition) {
+    public Slice<PostResponse> searchGetPost(Pageable pageable, PostSearchCondition condition) {
 
-        List<PostResponse> postResponses = queryFactory
+        List<PostResponse> content = queryFactory
                 .select(Projections.constructor(PostResponse.class,
                         post.id,
                         post.title,
@@ -33,25 +32,24 @@ public class PostRepositoryImpl implements PostRepositoryCustom{
                         post.createdAt
                 ))
                 .from(post)
+                .join(post.author)
                 .where(
                         postTitleEq(condition.title()),
                         postContent(condition.content()),
                         postAuthorNickname(condition.authorNickname())
                 )
+                .orderBy(post.createdAt.desc())
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        JPAQuery<Long> countQuery = queryFactory
-                .select(post.count())
-                .from(post)
-                .where(
-                        postTitleEq(condition.title()),
-                        postContent(condition.content()),
-                        postAuthorNickname(condition.authorNickname())
-                );
+        boolean hasNext = false;
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            hasNext = true;
+        }
 
-        return PageableExecutionUtils.getPage(postResponses, pageable, countQuery::fetchOne);
+        return new SliceImpl<>(content, pageable, hasNext);
     }
 
     private BooleanExpression postTitleEq(String title) {

--- a/backend/src/main/java/com/mateandgit/devstep/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/mateandgit/devstep/domain/post/service/PostService.java
@@ -14,6 +14,7 @@ import com.mateandgit.devstep.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,8 +40,7 @@ public class PostService {
         return savedPost.getId();
     }
 
-    // TODO: Fetch Join이나 EntityGraph 적용해서 Post 조회 시 Comment와 Author 한 번에 가져오기
-    public Page<PostResponse> getPostList(Pageable pageable, PostSearchCondition condition) {
+    public Slice<PostResponse> getPostList(Pageable pageable, PostSearchCondition condition) {
         return postRepository.searchGetPost(pageable, condition);
     }
 


### PR DESCRIPTION
# [PERF] Optimize Post List Retrieval Performance (#22)

## Description
This PR optimizes the performance of the post list retrieval API. By introducing a database index and switching from `Page` to `Slice` pagination, we significantly reduced query latency and improved system throughput for large datasets (100k+ records).

- Closes #22

## Key Changes
- [x] **Database Indexing**: Added a descending index on `created_at` in the `Post` entity to optimize sorting performance.
- [x] **Pagination Optimization**: Replaced `Page` with `Slice` to eliminate heavy `count(*)` queries that scan the entire table.
- [x] **Query Tuning**: Implemented Querydsl `Projections` for direct DTO mapping and added explicit joins to prevent N+1 issues.
- [x] **Benchmark Validation**: Verified performance improvement using k6 load testing tool.

## Checklist
- [x] Are sensitive files (e.g., `application.yml`) excluded?
- [x] Did you pass all local tests?
- [x] Does the code follow the project's style guidelines?

## Additional Context
### 📊 Benchmark Results (Before vs After)
| Metric | Before (Baseline) | After (Optimized) | Improvement |
| :--- | :--- | :--- | :--- |
| **p(95) Latency** | 514.53ms | **446.28ms** | **13.2% ↓** |
| **Throughput** | 79.01 req/s | **97.71 req/s** | **23.6% ↑** |

### 🔍 Optimization Impact
- **DB Execution Time**: Reduced from ~76ms to **0.8ms** per query.
- **Scalability**: The system now maintains stable performance even with 100,000+ posts by avoiding Full Table Scans.